### PR TITLE
feat: implement heroui themed design system

### DIFF
--- a/src/app/layouts/Chrome.tsx
+++ b/src/app/layouts/Chrome.tsx
@@ -6,14 +6,14 @@ import { Outlet } from "react-router-dom";
 export default function Chrome() {
     // return overall layout
     return (
-        <div className="flex min-h-screen">
+        <div className="flex min-h-screen bg-background text-foreground">
             {/* Sidebar placeholder */}
-            <aside className="w-64 border-r border-gray-200 bg-white dark:bg-slate-900">
+            <aside className="w-64 border-r border-default-200/80 bg-default-50/80 backdrop-blur-sm dark:border-default-200/20 dark:bg-default-50/10">
                 {/* TODO: add navigation here */}
             </aside>
 
             {/* Main content area */}
-            <main className="flex-1 overflow-y-auto">
+            <main className="flex-1 overflow-y-auto bg-background">
                 {/* Outlet renders current route */}
                 <Outlet />
             </main>

--- a/src/features/landing/Hero.tsx
+++ b/src/features/landing/Hero.tsx
@@ -1,39 +1,67 @@
 // src/features/landing/Hero.tsx
 
+import { Button, Card, Chip } from "@heroui/react";
+
 export default function Hero() {
     return (
         <section className="relative isolate overflow-hidden">
-            <div className="mx-auto max-w-7xl px-6 pt-24 pb-16 sm:pt-32 sm:pb-20 lg:px-8">
+            {/* Soft atmospheric glow that adapts to both themes */}
+            <div
+                aria-hidden="true"
+                className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/15 via-background/60 to-background dark:from-primary/30 dark:via-background/30 dark:to-background"
+            />
+
+            <div className="mx-auto max-w-7xl px-6 pt-24 pb-20 sm:pt-32 lg:px-8">
                 {/* Text block */}
-                <div className="mx-auto max-w-3xl text-center">
-                    <h1 className="text-4xl font-extrabold tracking-tight sm:text-6xl bg-clip-text text-transparent bg-gradient-to-r from-red-500 to-yellow-400">
-                        The Operating System for Service Businesses
+                <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+                    <Chip
+                        className="mb-6 border border-secondary/40 bg-secondary/10 text-secondary-700 shadow-sm dark:border-secondary/25 dark:bg-secondary/15 dark:text-secondary-200"
+                        radius="full"
+                        size="lg"
+                        variant="flat"
+                    >
+                        Built for modern field service teams
+                    </Chip>
+
+                    <h1 className="text-balance text-4xl font-extrabold tracking-tight sm:text-6xl">
+                        <span className="bg-gradient-to-r from-primary via-primary/70 to-secondary bg-clip-text text-transparent">
+                            The Operating System for Service Businesses
+                        </span>
                     </h1>
-                    <p className="mt-6 text-lg text-gray-700 dark:text-gray-300">
-                        Run HVAC, Spray Foam, Plumbing, and more—smarter, faster, with total control.
+                    <p className="mt-6 max-w-2xl text-lg text-default-500">
+                        Run HVAC, spray foam, plumbing, and more—smarter, faster, and with total control across every job,
+                        crew, and customer touchpoint.
                     </p>
                 </div>
 
                 {/* Call-to-actions */}
-                <div className="mt-8 flex items-center justify-center gap-4">
-                    <button className="rounded-xl px-6 py-3 bg-red-500 hover:bg-red-600 text-white font-semibold shadow-lg">
+                <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+                    <Button
+                        className="px-8 shadow-lg shadow-primary/30"
+                        color="primary"
+                        radius="full"
+                        size="lg"
+                        variant="solid"
+                    >
                         Get Started Free
-                    </button>
-                    <button className="rounded-xl px-6 py-3 border font-semibold
-                             bg-white text-gray-700 border-gray-300 hover:bg-gray-100
-                             dark:bg-white/10 dark:border-white/15 dark:text-gray-200 dark:hover:bg-white/20">
+                    </Button>
+                    <Button
+                        className="px-8"
+                        color="secondary"
+                        radius="full"
+                        size="lg"
+                        variant="bordered"
+                    >
                         See BossOS in Action
-                    </button>
+                    </Button>
                 </div>
 
                 {/* Visual placeholder */}
-                <div className="mt-12 w-full max-w-5xl mx-auto">
-                    <div className="aspect-video rounded-2xl shadow-2xl flex items-center justify-center
-                          bg-gray-200 text-gray-500
-                          dark:bg-gradient-to-br dark:from-gray-800 dark:to-gray-900">
+                <Card className="mx-auto mt-12 w-full max-w-5xl border border-default-200/60 bg-default-50/80 backdrop-blur-md dark:border-default-200/30 dark:bg-default-50/10" radius="lg">
+                    <div className="flex aspect-video w-full items-center justify-center text-base font-medium text-default-500">
                         Dashboard Mockup Placeholder
                     </div>
-                </div>
+                </Card>
             </div>
         </section>
     )

--- a/src/features/landing/Landing.tsx
+++ b/src/features/landing/Landing.tsx
@@ -4,7 +4,7 @@ import Hero from "./Hero"
 
 export default function Landing() {
     return (
-        <div className="flex flex-col min-h-screen bg-gray-950 text-gray-50">
+        <div className="flex min-h-screen flex-col bg-background text-foreground transition-colors duration-300">
             {/* Hero Section */}
             <Hero />
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -3,10 +3,27 @@
 
 @layer base {
   :root {
-    color-scheme: light dark;
+    color-scheme: light;
+  }
+
+  .dark {
+    color-scheme: dark;
   }
 
   body {
-    @apply bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
+    @apply bg-background text-foreground antialiased;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-semibold tracking-tight text-foreground;
+  }
+
+  p {
+    @apply text-default-500;
   }
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,13 +1,169 @@
-import { heroui } from "@heroui/react";
+import { createTheme, heroui } from "@heroui/react";
 import { createRequire } from "module";
 import path from "path";
 
 const require = createRequire(import.meta.url);
 const herouiThemeDist = path.join(
   path.dirname(require.resolve("@heroui/theme/package.json")),
-  "dist"
+  "dist",
 );
 const heroUiContentGlob = `${herouiThemeDist.replace(/\\/g, "/")}/**/*.{js,ts,jsx,tsx,mjs}`;
+
+// Signature brand palettes that power both the Tailwind + HeroUI tokens
+const bossLight = createTheme({
+  extend: "light",
+  layout: {
+    radius: {
+      small: "0.6rem",
+      medium: "0.85rem",
+      large: "1.25rem",
+    },
+    borderWidth: {
+      small: "1px",
+      medium: "1.5px",
+      large: "2px",
+    },
+    fontSize: {
+      tiny: "0.75rem",
+      small: "0.875rem",
+      medium: "1rem",
+      large: "1.125rem",
+      huge: "3.5rem",
+    },
+    disabledOpacity: 0.45,
+  },
+  colors: {
+    background: "#fdfcf9",
+    foreground: "#0f172a",
+    focus: "#facc15",
+    border: "#e5e7eb",
+    divider: "#e5e7eb",
+    primary: {
+      50: "#fef2f2",
+      100: "#fee2e2",
+      200: "#fecaca",
+      300: "#fca5a5",
+      400: "#f87171",
+      500: "#ef4444",
+      600: "#dc2626",
+      700: "#b91c1c",
+      800: "#991b1b",
+      900: "#7f1d1d",
+      DEFAULT: "#ef4444",
+      foreground: "#ffffff",
+    },
+    secondary: {
+      50: "#fefce8",
+      100: "#fef08a",
+      200: "#fde047",
+      300: "#facc15",
+      400: "#f59e0b",
+      500: "#facc15",
+      600: "#eab308",
+      700: "#ca8a04",
+      800: "#a16207",
+      900: "#854d0e",
+      DEFAULT: "#facc15",
+      foreground: "#422006",
+    },
+    default: {
+      50: "#f8fafc",
+      100: "#f1f5f9",
+      200: "#e2e8f0",
+      300: "#cbd5f5",
+      400: "#94a3b8",
+      500: "#64748b",
+      600: "#475569",
+      700: "#334155",
+      800: "#1e293b",
+      900: "#0f172a",
+      foreground: "#0f172a",
+    },
+    success: {
+      500: "#22c55e",
+      600: "#16a34a",
+      foreground: "#052e16",
+    },
+    warning: {
+      500: "#f97316",
+      600: "#ea580c",
+      foreground: "#431407",
+    },
+    danger: {
+      500: "#ef4444",
+      600: "#dc2626",
+      foreground: "#450a0a",
+    },
+  },
+});
+
+const bossDark = createTheme({
+  extend: "dark",
+  layout: bossLight.layout,
+  colors: {
+    background: "#0b0f14",
+    foreground: "#f8fafc",
+    focus: "#facc15",
+    border: "#1f2933",
+    divider: "#1f2933",
+    primary: {
+      50: "#2b0b0b",
+      100: "#3d1111",
+      200: "#5a1616",
+      300: "#7a1a1a",
+      400: "#a11f1f",
+      500: "#ef4444",
+      600: "#f87171",
+      700: "#fca5a5",
+      800: "#fecaca",
+      900: "#fee2e2",
+      DEFAULT: "#ef4444",
+      foreground: "#fff7f7",
+    },
+    secondary: {
+      50: "#2d2004",
+      100: "#3f2f07",
+      200: "#604909",
+      300: "#825f0b",
+      400: "#a87c0e",
+      500: "#facc15",
+      600: "#fde047",
+      700: "#fef08a",
+      800: "#fef9c3",
+      900: "#fffbeb",
+      DEFAULT: "#facc15",
+      foreground: "#201500",
+    },
+    default: {
+      50: "#101621",
+      100: "#151d2c",
+      200: "#1d2739",
+      300: "#253145",
+      400: "#303e56",
+      500: "#3c4a67",
+      600: "#4b5b7c",
+      700: "#627294",
+      800: "#7d8bae",
+      900: "#9aa6c7",
+      foreground: "#f8fafc",
+    },
+    success: {
+      500: "#22c55e",
+      600: "#4ade80",
+      foreground: "#042f14",
+    },
+    warning: {
+      500: "#f97316",
+      600: "#fb923c",
+      foreground: "#431407",
+    },
+    danger: {
+      500: "#f87171",
+      600: "#fca5a5",
+      foreground: "#450a0a",
+    },
+  },
+});
 
 export default {
   content: [
@@ -15,9 +171,28 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
     heroUiContentGlob,
   ],
-  theme: {
-    extend: {},
-  },
   darkMode: "class",
-  plugins: [heroui()],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: [
+          "'Inter'",
+          "var(--font-sans, ui-sans-serif)",
+          "system-ui",
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "'Segoe UI'",
+          "sans-serif",
+        ],
+      },
+    },
+  },
+  plugins: [
+    heroui({
+      themes: {
+        light: bossLight,
+        dark: bossDark,
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary
- configure Tailwind + HeroUI with BossOS-branded light and dark themes, including shared layout tokens
- refresh global styles and application chrome to use semantic background/foreground utilities from the new theme
- modernize the landing hero with HeroUI components and gradients that showcase the primary/secondary palette

## Testing
- pnpm lint *(fails: existing lint errors in legacy files outside the new theme work)*

------
https://chatgpt.com/codex/tasks/task_e_68dc984ad4b48328aa5887cd2619e991